### PR TITLE
Move `Whitewash` to a command

### DIFF
--- a/plugin/whitewash.vim
+++ b/plugin/whitewash.vim
@@ -1,10 +1,13 @@
-function! Whitewash()
-  %s/\v(\s|)*$//
+command! Whitewash call <sid>whitewash()
+
+function! s:whitewash()
+  %s/\v(\s|
+)*$//
   retab
   ''
 endfunction
 
-autocmd FileWritePre * :call Whitewash()
-autocmd FileAppendPre * :call Whitewash()
-autocmd FilterWritePre * :call Whitewash()
-autocmd BufWritePre * :call Whitewash()
+autocmd FileWritePre * :Whitewash
+autocmd FileAppendPre * :Whitewash
+autocmd FilterWritePre * :Whitewash
+autocmd BufWritePre * :Whitewash


### PR DESCRIPTION
`:call Whitewash()<CR>` is kind of annoying. Instead, it'd be nice to just be able to do `:Whitewash<CR>`, which is shorter and cooler.